### PR TITLE
Add websocket to get backend progress

### DIFF
--- a/src/api/GetAPI.ts
+++ b/src/api/GetAPI.ts
@@ -21,7 +21,6 @@ export const fetchSubAssignments = async (id: string, token: string | null): Pro
         const response = await axios.get(`${API_PREFIX}/assignments/${id}`, { headers });
         return response.data;
     } catch (error) {
-        console.error('課題データの取得に失敗しました', error);
         throw error;
     }
 };
@@ -29,7 +28,6 @@ export const fetchSubAssignments = async (id: string, token: string | null): Pro
 // APIからドロップダウンで選択された課題の詳細情報を取得する関数
 export const fetchSubAssignmentDetail = async (id: string, sub_id: string, token: string | null): Promise<SubAssignmentDetail | null> => {
     try {
-        console.log(`token: ${token}`)
         const headers = token ? { Authorization: `Bearer ${token}` } : {};
         const response = await axios.get(`${API_PREFIX}/assignments/${id}/${sub_id}`, { headers });
         return response.data;
@@ -42,7 +40,6 @@ export const fetchUserList = async (token: string | null): Promise<User[]> => {
     try {
         const headers = token ? { Authorization: `Bearer ${token}` } : {};
         const response = await axios.get(`${API_PREFIX}/users/all`, { headers });
-        console.log(response.data)
         return response.data;
     } catch (error) {
         throw error;

--- a/src/api/PostAPI.ts
+++ b/src/api/PostAPI.ts
@@ -1,10 +1,10 @@
 import axios from 'axios';
 import { LoginCredentials, CreateUser } from '../types/user';
 import { Token } from '../types/token';
+import { ProgressMessage } from '../types/Assignments';
 
 const API_PREFIX = 'http://localhost:8000/api/v1';
-
-// ファイルをアップロードする関数
+// ファイルをアップロードする関数(多分uploadFileWithProgressに切り替える)
 export const uploadFile = async (file: File, id: number, sub_id: number): Promise<string> => {
     const formData = new FormData();
     formData.append("file", file);
@@ -14,10 +14,8 @@ export const uploadFile = async (file: File, id: number, sub_id: number): Promis
             "Content-Type": "multipart/form-data",
             },
         });
-        console.log('File uploaded successfully', response.data);
-        return response.data.result; // または適切なレスポンスを返します。
+        return response.data.filename; // uuidが付加されたファイル名を返す
     } catch (error) {
-        console.error('Error uploading file', error);
         throw error; // エラーを呼び出し元に伝播させる
     }
 };
@@ -27,10 +25,8 @@ export const createUser = async (user: CreateUser, token: string | null): Promis
     try {
         const headers = token ? { Authorization: `Bearer ${token}` } : {};
         const response = await axios.post(`${API_PREFIX}/users/register`, user, { headers });
-        console.log('User created successfully', response.data);
         return response.data.result;
     } catch (error) {
-        console.error('Error creating user', error);
         throw error;
     }
 }
@@ -45,7 +41,6 @@ export const login = async (credentials: LoginCredentials): Promise<Token> => {
         const response = await axios.post<Token>(`${API_PREFIX}/authorize/token`, formData);
         return response.data; 
     } catch (error) {
-        console.error('Error logging in', error);
         throw error;
     }
 }
@@ -55,7 +50,6 @@ export const logout = async (token: string): Promise<void> => {
         const headers = { Authorization: `Bearer ${token}` };
         await axios.post(`${API_PREFIX}/authorize/logout`, {}, { headers });
     } catch (error) {
-        console.error('Error logging out', error);
         throw error;
     }
 }

--- a/src/api/WebSocketAPI.ts
+++ b/src/api/WebSocketAPI.ts
@@ -13,37 +13,46 @@ export const startProcessingWithProgress = (
     { onProgress }: WebSocketCallbacks
 ) => {
     const ws = new WebSocket(`${API_WS_PREFIX}/assignments/ws/${id}/${sub_id}`);
+    let lastHeartbeat = Date.now();
+
+    const checkHeartbeat = () => {
+        if (ws.readyState === WebSocket.CLOSED) {
+            return; // WebSocketが閉じている場合は、チェックを中止
+        }
+    
+        const now = Date.now();
+        if (now - lastHeartbeat > 20000) {  // 最後のハートビートから20秒以上経過している場合
+            console.error("Connection lost or server is down");
+            onProgress({ status: 'error', message: 'サーバーとの接続が切れました. 再度アップロードボタンを押して再試行してください．', progress_percentage: -1 });
+            ws.close();
+        } else {
+            setTimeout(checkHeartbeat, 10000);  // 10秒後に再度チェック
+        }
+    };
 
     ws.onopen = () => {
         // WebSocket接続が開かれたら、filenameを送信
         ws.send(JSON.stringify({ filename }));
+        setTimeout(checkHeartbeat, 10000);  // 接続後10秒後に最初のハートビートチェックを開始
     };
 
     ws.onmessage = (event) => {
         try {
-        const data = JSON.parse(event.data);
-        switch (data.status) {
-            case 'progress':
+            const data = JSON.parse(event.data);
+            if (data.type === "heartbeat" && data.message === "ping") {
+                lastHeartbeat = Date.now();  // ハートビートのタイムスタンプを更新
+            } else {
                 onProgress(data);
-                break;
-            case 'done':
-                onProgress(data);
-                break;
-            case 'error':
-                onProgress(data);
-                break;
-            default:
-            console.error('Unknown message type:', data);
-        }
+            }
         } catch (error) {
             console.error('Error parsing message:', error);
-            onProgress({ status: 'error', message: 'メッセージの解析に失敗しました。', progress_percentage: -1 });
+            onProgress({ status: 'error', message: 'メッセージの解析に失敗しました．', progress_percentage: -1 });
         }
     };
 
     ws.onerror = (event) => {
         console.error('WebSocket error:', event);
-        onProgress({ status: 'error', message: 'WebSocketエラーが発生しました。', progress_percentage: -1 });
+        onProgress({ status: 'error', message: 'WebSocketエラーが発生しました．', progress_percentage: -1 });
     };
 
     ws.onclose = (event) => {

--- a/src/api/WebSocketAPI.ts
+++ b/src/api/WebSocketAPI.ts
@@ -14,19 +14,23 @@ export const startProcessingWithProgress = (
 ) => {
     const ws = new WebSocket(`${API_WS_PREFIX}/assignments/ws/${id}/${sub_id}`);
     let lastHeartbeat = Date.now();
+    let processingCompleted = false;
+    let heartbeatTimerId: NodeJS.Timeout | null = null;
 
     const checkHeartbeat = () => {
-        if (ws.readyState === WebSocket.CLOSED) {
+        if (ws.readyState === WebSocket.CLOSED && processingCompleted) {
             return; // WebSocketが閉じている場合は、チェックを中止
         }
-    
+        if (heartbeatTimerId !== null) {
+            clearTimeout(heartbeatTimerId);
+        }
         const now = Date.now();
         if (now - lastHeartbeat > 20000) {  // 最後のハートビートから20秒以上経過している場合
             console.error("Connection lost or server is down");
             onProgress({ status: 'error', message: 'サーバーとの接続が切れました. 再度アップロードボタンを押して再試行してください．', progress_percentage: -1 });
             ws.close();
         } else {
-            setTimeout(checkHeartbeat, 10000);  // 10秒後に再度チェック
+            setTimeout(checkHeartbeat, 5000);  // 5秒後に再度チェック
         }
     };
 
@@ -39,10 +43,14 @@ export const startProcessingWithProgress = (
     ws.onmessage = (event) => {
         try {
             const data = JSON.parse(event.data);
+            console.log('Received message:', data);
             if (data.type === "heartbeat" && data.message === "ping") {
                 lastHeartbeat = Date.now();  // ハートビートのタイムスタンプを更新
             } else {
                 onProgress(data);
+                if (data.status === 'done') {
+                    processingCompleted = true;
+                }
             }
         } catch (error) {
             console.error('Error parsing message:', error);
@@ -56,11 +64,12 @@ export const startProcessingWithProgress = (
     };
 
     ws.onclose = (event) => {
-        if (event.wasClean) {
-            // console.log('WebSocket closed cleanly');
-        } else {
+        if (heartbeatTimerId !== null) {
+            clearTimeout(heartbeatTimerId);
+        }
+        if (!event.wasClean) {
             console.error('WebSocket closed with error:', event);
-            onProgress({ status: 'error', message: 'WebSocketが予期せず閉じました。', progress_percentage: -1 });
+            onProgress({ status: 'error', message: 'WebSocketが予期せず閉じました. 再度アップロードボタンを押して再試行してください.', progress_percentage: -1 });
         }
     };
 

--- a/src/api/WebSocketAPI.ts
+++ b/src/api/WebSocketAPI.ts
@@ -1,0 +1,62 @@
+import { ProgressMessage } from '../types/Assignments';
+
+const API_WS_PREFIX = 'ws://localhost:8000/api/v1';
+
+interface WebSocketCallbacks {
+    onProgress: (progress: ProgressMessage) => void;
+}
+
+export const startProcessingWithProgress = (
+    id: number,
+    sub_id: number,
+    filename: string,
+    { onProgress }: WebSocketCallbacks
+) => {
+    const ws = new WebSocket(`${API_WS_PREFIX}/assignments/ws/${id}/${sub_id}`);
+
+    ws.onopen = () => {
+        // WebSocket接続が開かれたら、filenameを送信
+        ws.send(JSON.stringify({ filename }));
+    };
+
+    ws.onmessage = (event) => {
+        try {
+        const data = JSON.parse(event.data);
+        switch (data.status) {
+            case 'progress':
+                onProgress(data);
+                break;
+            case 'done':
+                onProgress(data);
+                break;
+            case 'error':
+                onProgress(data);
+                break;
+            default:
+            console.error('Unknown message type:', data);
+        }
+        } catch (error) {
+            console.error('Error parsing message:', error);
+            onProgress({ status: 'error', message: 'メッセージの解析に失敗しました。', progress_percentage: -1 });
+        }
+    };
+
+    ws.onerror = (event) => {
+        console.error('WebSocket error:', event);
+        onProgress({ status: 'error', message: 'WebSocketエラーが発生しました。', progress_percentage: -1 });
+    };
+
+    ws.onclose = (event) => {
+        if (event.wasClean) {
+            // console.log('WebSocket closed cleanly');
+        } else {
+            console.error('WebSocket closed with error:', event);
+            onProgress({ status: 'error', message: 'WebSocketが予期せず閉じました。', progress_percentage: -1 });
+        }
+    };
+
+    // WebSocket接続を閉じる関数を返す
+    return () => {
+        ws.close();
+    };
+};

--- a/src/components/FileUploadBox.tsx
+++ b/src/components/FileUploadBox.tsx
@@ -7,9 +7,10 @@ interface FileUploadProps {
     sub_id: number;
     fileName: string;
     onProgressUpdate: (progress: ProgressMessage | null) => void; // 進行状況を親コンポーネントに通知するためのコールバック
+    isProcessing?: boolean;
 }
 
-const FileUpload: React.FC<FileUploadProps> = ({ id, sub_id, fileName, onProgressUpdate }) => {
+const FileUpload: React.FC<FileUploadProps> = ({ id, sub_id, fileName, onProgressUpdate, isProcessing }) => {
     const [file, setFile] = useState<File | null>(null);
     const [isNameCorrect, setIsNameCorrect] = useState<boolean | null>(null);
     const [error, setError] = useState<string | null>(null);
@@ -85,11 +86,11 @@ const FileUpload: React.FC<FileUploadProps> = ({ id, sub_id, fileName, onProgres
                 {/* Always reserve space for error message */}
                 <p style={{ color: 'red', minHeight: '20px' }}>{isNameCorrect !== null && !isNameCorrect ? `ファイル名が違います．${fileName}を提出してください．` : ''}</p>
                 <input type="file" onChange={handleFileChange} ref={fileInputRef} style={{ display: 'none' }} />
-                <button type="button" onClick={() => fileInputRef.current?.click()} style={{ width: 'auto', padding: '10px', margin: '10px 0' }}>ファイルを選択</button>
+                <button disabled={isProcessing} type="button" onClick={() => fileInputRef.current?.click()} style={{ width: 'auto', padding: '10px', margin: '10px 0' }}>ファイルを選択</button>
             </div>
             <div style={{ display: 'flex', justifyContent: 'center', gap: '10px', marginTop: '20px' }}>
                 <button type="button" onClick={handleCancel} disabled={!file} style={{ width: 'auto', padding: '10px' }}>選択取り消し</button>
-                <button type="button" onClick={handleSubmit} disabled={!file || !isNameCorrect} style={{ width: 'auto', padding: '10px' }}>アップロード</button>
+                <button type="button" onClick={handleSubmit} disabled={!file || !isNameCorrect || isProcessing} style={{ width: 'auto', padding: '10px' }}>アップロード</button>
             </div>
         </>
     );

--- a/src/components/FileUploadBox.tsx
+++ b/src/components/FileUploadBox.tsx
@@ -1,20 +1,22 @@
 import React, { useState, useRef } from 'react';
 import { uploadFile } from '../api/PostAPI';
-
+import { startProcessingWithProgress } from '../api/WebSocketAPI';
+import { ProgressMessage } from '../types/Assignments';
 interface FileUploadProps {
     id: number;
     sub_id: number;
     fileName: string;
-    fileNum?: number;
+    onProgressUpdate: (progress: ProgressMessage | null) => void; // 進行状況を親コンポーネントに通知するためのコールバック
 }
 
-const FileUpload: React.FC<FileUploadProps> = ({ id, sub_id, fileName, fileNum }) => {
+const FileUpload: React.FC<FileUploadProps> = ({ id, sub_id, fileName, onProgressUpdate }) => {
     const [file, setFile] = useState<File | null>(null);
+    const [isNameCorrect, setIsNameCorrect] = useState<boolean | null>(null);
     const [error, setError] = useState<string | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
 
     const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setError(null);
+        setIsNameCorrect(null);
         const files = event.target.files;
         processFile(files);
     };
@@ -27,6 +29,7 @@ const FileUpload: React.FC<FileUploadProps> = ({ id, sub_id, fileName, fileNum }
         event.preventDefault();
         const files = event.dataTransfer.files;
         processFile(files);
+        setError(null);
     };
 
     const processFile = (files: FileList | null) => {
@@ -34,16 +37,17 @@ const FileUpload: React.FC<FileUploadProps> = ({ id, sub_id, fileName, fileNum }
             const selectedFile = files[0];
             setFile(selectedFile); // Always set the file
             if (selectedFile.name !== fileName) {
-                setError(`ファイル名が違います．${fileName}を提出してください．`);
+                setIsNameCorrect(false);
                 // Do not return here to keep the file selected even if the name is different
             } else {
-                setError(null); // Clear error if file name matches
+                setIsNameCorrect(true); // Clear error if file name matches
             }
         }
     };
 
     const handleCancel = () => {
         setFile(null);
+        setIsNameCorrect(null);
         setError(null);
         if (fileInputRef.current) {
             fileInputRef.current.value = '';
@@ -52,13 +56,22 @@ const FileUpload: React.FC<FileUploadProps> = ({ id, sub_id, fileName, fileNum }
 
     const handleSubmit = async (event: React.FormEvent) => {
         event.preventDefault();
-        if (file && !error) { // Only attempt to upload if there's a file and no error
+        if (file && isNameCorrect) {
             try {
                 const filename = await uploadFile(file, id, sub_id);
-                console.log(`File uploaded: ${filename}`);
-                setError(null);
+                // WebSocket 通信を開始し、進行状況を受信
+                startProcessingWithProgress(
+                    id,
+                    sub_id,
+                    filename,
+                    {
+                        onProgress: (progress) => {
+                            onProgressUpdate(progress); // 進行状況を親コンポーネントに通知
+                        }
+                    }
+                );
             } catch (error) {
-                console.error('Error uploading file');
+                console.error('Error uploading file', error);
                 setError('Failed to upload the file.');
             }
         }
@@ -70,13 +83,13 @@ const FileUpload: React.FC<FileUploadProps> = ({ id, sub_id, fileName, fileNum }
                 onDragOver={handleDragOver} onDrop={handleDrop}>
                 <p>{file ? file.name : 'ファイルを選択してください'}</p>
                 {/* Always reserve space for error message */}
-                <p style={{ color: 'red', minHeight: '20px' }}>{error ? error : ''}</p>
+                <p style={{ color: 'red', minHeight: '20px' }}>{isNameCorrect !== null && !isNameCorrect ? `ファイル名が違います．${fileName}を提出してください．` : ''}</p>
                 <input type="file" onChange={handleFileChange} ref={fileInputRef} style={{ display: 'none' }} />
                 <button type="button" onClick={() => fileInputRef.current?.click()} style={{ width: 'auto', padding: '10px', margin: '10px 0' }}>ファイルを選択</button>
             </div>
             <div style={{ display: 'flex', justifyContent: 'center', gap: '10px', marginTop: '20px' }}>
                 <button type="button" onClick={handleCancel} disabled={!file} style={{ width: 'auto', padding: '10px' }}>選択取り消し</button>
-                <button type="button" onClick={handleSubmit} disabled={!file || error !== null} style={{ width: 'auto', padding: '10px' }}>アップロード</button>
+                <button type="button" onClick={handleSubmit} disabled={!file || !isNameCorrect} style={{ width: 'auto', padding: '10px' }}>アップロード</button>
             </div>
         </>
     );

--- a/src/components/FileUploadBox.tsx
+++ b/src/components/FileUploadBox.tsx
@@ -89,7 +89,7 @@ const FileUpload: React.FC<FileUploadProps> = ({ id, sub_id, fileName, onProgres
                 <button disabled={isProcessing} type="button" onClick={() => fileInputRef.current?.click()} style={{ width: 'auto', padding: '10px', margin: '10px 0' }}>ファイルを選択</button>
             </div>
             <div style={{ display: 'flex', justifyContent: 'center', gap: '10px', marginTop: '20px' }}>
-                <button type="button" onClick={handleCancel} disabled={!file} style={{ width: 'auto', padding: '10px' }}>選択取り消し</button>
+                <button type="button" onClick={handleCancel} disabled={!file || isProcessing} style={{ width: 'auto', padding: '10px' }}>選択取り消し</button>
                 <button type="button" onClick={handleSubmit} disabled={!file || !isNameCorrect || isProcessing} style={{ width: 'auto', padding: '10px' }}>アップロード</button>
             </div>
         </>

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,43 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { ProgressMessage } from '../types/Assignments';
+
+interface ProgressBarProps {
+    progress: ProgressMessage;
+}
+
+const ProgressBar: React.FC<ProgressBarProps> = ({ progress }) => {
+    const isError = progress.status === "error" || progress.progress_percentage < 0;
+    return (
+        <div aria-valuenow={progress.progress_percentage} aria-valuemin={0} aria-valuemax={100} role="progressbar" style={{ display: 'block' }}>
+            <ProgressMessageText isError={isError}>{progress.message}</ProgressMessageText>
+            <ProgressBarContainer>
+                <Progress progress_percentage={progress.progress_percentage} isError={isError}>
+                    {progress.progress_percentage}%
+                </Progress>
+            </ProgressBarContainer>
+        </div>
+    );
+};
+
+export default ProgressBar;
+
+const ProgressMessageText = styled.div<{ isError?: boolean }>`
+    color: ${props => props.isError ? 'red' : 'black'};
+    padding: 5px;
+`;
+
+const ProgressBarContainer = styled.div`
+    width: 100%;
+    background-color: #ddd;
+    border: 1px solid #bbb;
+`;
+
+const Progress = styled.div<{ progress_percentage: number; isError?: boolean }>`
+    width: ${props => props.progress_percentage}%;
+    background-color: ${props => props.isError ? 'red' : '#5AFF19'};
+    text-align: center;
+    color: black;
+    padding: 5px 0;
+    transition: width 0.5s ease-in-out;
+`;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -16,7 +16,6 @@ const LoginPage: React.FC = () => {
         e.preventDefault();
         try {
             const result = await login(credentials);
-            console.log('Login successful:', result);
             setError('');
             setToken(result.access_token); 
             setUserId(result.user_id);

--- a/src/pages/SubmissionPage.tsx
+++ b/src/pages/SubmissionPage.tsx
@@ -7,11 +7,13 @@ import CodeBlock from '../components/CodeBlock';
 import Accordion from '../components/Accordion';
 import FileUploadBox from '../components/FileUploadBox';
 import {useAuth} from '../context/AuthContext';
-
+import { ProgressMessage } from '../types/Assignments';
+import ProgressBar from '../components/ProgressBar';
 const SubmissionPage: React.FC = () => {
 	const { problemNum } = useParams<{ problemNum: string }>();
 	const [subAssignmentsDropdown, setSubAssignmentsDropdown] = useState<SubAssignmentDropdown[]>([]);
 	const [subAssignmentDetail, setSubAssignmentDetail] = useState<SubAssignmentDetail | null>(null);
+	const [progressMessage, setProgressMessage] = useState<ProgressMessage | null>(null);
 	const [hasError, setHasError] = useState(false);
 	const { token } = useAuth();
 	useEffect(() => {
@@ -24,6 +26,7 @@ const SubmissionPage: React.FC = () => {
 				setHasError(true); // エラーが発生した場合はエラー状態をtrueに
 			}
 		};
+		setProgressMessage(null);
 		setSubAssignmentsDropdown([]);
 		setSubAssignmentDetail(null);
 		getSubAssignmentsDropdown();
@@ -80,17 +83,13 @@ const SubmissionPage: React.FC = () => {
 					)}
 					<h3>提出</h3>
 					<p>指定されたファイルを選択し，アップロードしてください．ファイルはドラッグ&ドロップでも選択可能です．</p>
-					<FileUploadBox id={subAssignmentDetail.id} sub_id={subAssignmentDetail.sub_id} fileName={subAssignmentDetail.required_file_name} fileNum={1} />
+					<FileUploadBox id={subAssignmentDetail.id} sub_id={subAssignmentDetail.sub_id} fileName={subAssignmentDetail.required_file_name} onProgressUpdate={setProgressMessage} />
+					{progressMessage && <ProgressBar progress={progressMessage} />}
 				</div>
 			)}
 		</div>
 	);
-	return (
-		<div>
-		<h1>課題{problemNum}確認ページ</h1>
-		<p>問題番号 {problemNum} に対する提出作業を行ってください。</p>
-		</div>
-	);
+	
 };
 
 export default SubmissionPage;

--- a/src/pages/SubmissionPage.tsx
+++ b/src/pages/SubmissionPage.tsx
@@ -83,7 +83,7 @@ const SubmissionPage: React.FC = () => {
 					)}
 					<h3>提出</h3>
 					<p>指定されたファイルを選択し，アップロードしてください．ファイルはドラッグ&ドロップでも選択可能です．</p>
-					<FileUploadBox id={subAssignmentDetail.id} sub_id={subAssignmentDetail.sub_id} fileName={subAssignmentDetail.required_file_name} onProgressUpdate={setProgressMessage} />
+					<FileUploadBox id={subAssignmentDetail.id} sub_id={subAssignmentDetail.sub_id} fileName={subAssignmentDetail.required_file_name} onProgressUpdate={setProgressMessage} isProcessing={!!progressMessage && progressMessage.progress_percentage >= 0 && progressMessage.progress_percentage < 100}/>
 					{progressMessage && <ProgressBar progress={progressMessage} />}
 				</div>
 			)}

--- a/src/pages/UserDeletePage.tsx
+++ b/src/pages/UserDeletePage.tsx
@@ -34,7 +34,6 @@ const UserDeletePage: React.FC = () => {
         
         try {
             await deleteUsers({user_ids: selectedUsers}, token);
-            console.log(`Deleting users with IDs: ${selectedUsers.join(', ')}`);
             alert('選択されたユーザーが正常に削除されました。');
             const updatedUserList = await fetchUserList(token);
             setUsers(updatedUserList);
@@ -48,6 +47,10 @@ const UserDeletePage: React.FC = () => {
     if (user_id === null) {
         return <p>ログインしていません。</p>;
     }
+    if (!is_admin) {
+        return <p>管理者権限がありません。</p>;
+    }
+
     return (
         <div>
             <h2>ユーザー削除</h2>

--- a/src/types/Assignments.ts
+++ b/src/types/Assignments.ts
@@ -17,10 +17,18 @@ export type SubAssignment = {
     test_input: string;
     test_output: string;
     test_program: string;
-  };
-  
+};
+
   // プルダウンで使用する型定義（問題名のみ）
-  export type SubAssignmentDropdown = Pick<SubAssignment, 'id' | 'sub_id' | 'title'>;
-  
-  // 選択された後に表示する情報用の型定義
-  export type SubAssignmentDetail = Pick<SubAssignment, 'id' | 'sub_id' | 'makefile' | 'required_file_name' | 'test_file_name' | 'test_input' | 'test_output' | 'test_program'>;
+export type SubAssignmentDropdown = Pick<SubAssignment, 'id' | 'sub_id' | 'title'>;
+
+// 選択された後に表示する情報用の型定義
+export type SubAssignmentDetail = Pick<SubAssignment, 'id' | 'sub_id' | 'makefile' | 'required_file_name' | 'test_file_name' | 'test_input' | 'test_output' | 'test_program'>;
+
+export type ProgressMessage = {
+    status: string;
+    message: string;
+    progress_percentage: number;
+    result?: { [key: string]: any }; 
+};
+


### PR DESCRIPTION
サーバー側のエラーがフロントに伝わらなかった時のためにwebsocket時にハートビートを使用した．一定時間通信が途絶えた時にエラーが発生する．

ファイル提出ボタンを押したあとは判定が完了するかエラーが出るまでボタンを押せなくする．ただし，処理中に処理を中断できないのでキャンセルボタンが必要か検討がいるかも．現状はページリロードでキャンセル可能．