### PR TITLE
ユーザーの一括登録機能を追加．登録項目も修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "@types/axios": "^0.14.0",
         "@types/jest": "^27.5.2",
         "@types/node": "^16.18.91",
         "@types/react": "^18.2.69",
         "@types/react-dom": "^18.2.22",
+        "axios": "^1.6.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^9.0.1",
@@ -4012,6 +4014,15 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
     },
+    "node_modules/@types/axios": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
+      "integrity": "sha512-KqQnQbdYE54D7oa/UmYVMZKq7CO4l8DEENzOKc4aBRwxCXSlJXGz83flFx5L7AWrOQnmuN3kVsRdt+GZPPjiVQ==",
+      "deprecated": "This is a stub types definition for axios (https://github.com/mzabriskie/axios). axios provides its own type definitions, so you don't need @types/axios installed!",
+      "dependencies": {
+        "axios": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -5307,6 +5318,29 @@
       "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
+      "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -15745,6 +15779,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,13 @@
+html, body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+#root {
+  height: 100%;
+}
+
 .app {
   display: flex;
   flex-direction: row;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Routes, Navigate } from 'react-router-dom';
 import Home from './pages/Home';
 import Sidebar from './components/Sidebar';
 import SubmissionPage from './pages/SubmissionPage';
@@ -8,37 +8,29 @@ import LoginPage from './pages/LoginPage';
 import UserDeletePage from './pages/UserDeletePage';
 import { useAuth } from './context/AuthContext';
 
+const PrivateRoute: React.FC<{ element: React.ReactElement }> = ({ element }) => {
+		const { token } = useAuth();
+		return token ? element : <Navigate to="/login" replace />;
+};
 
 const App: React.FC = () => {
-	const { resetTimer } = useAuth(); // useAuthフックからresetTimer関数を取得
-    useEffect(() => {
-        const events = ['click', 'load', 'keydown'];
-        // イベントリスナーを追加
-        events.forEach(event => window.addEventListener(event, resetTimer));
-        
-        // クリーンアップ関数
-        return () => {
-            events.forEach(event => window.removeEventListener(event, resetTimer));
-        };
-    }, [resetTimer]);
-
+	const { token } = useAuth();
     return (
-		<Router>
+			
 			<div className="app">
-				<Sidebar />
+				{token && <Sidebar />}
 				<div className="content">
-					<Routes>
-						<Route path="/" element={<Home />} />
-						<Route path="/submission/:problemNum" element={<SubmissionPage />} />
-						<Route path="/users/register" element={<RegisterPage />} />
-						<Route path="/login" element={<LoginPage />} />
-						<Route path="/users/delete" element={<UserDeletePage />} />
-						<Route path="*" element={<h1>Not Found</h1>} />
-					</Routes>
+				<Routes>
+					<Route path="/login" element={<LoginPage />} />
+					<Route path="/users/register" element={<PrivateRoute element={<RegisterPage />} />} />
+					<Route path="/" element={<PrivateRoute element={<Home />} />} />
+					<Route path="/submission/:problemNum" element={<PrivateRoute element={<SubmissionPage />} />} />
+					<Route path="/users/delete" element={<PrivateRoute element={<UserDeletePage />} />} />
+					<Route path="*" element={<h1>Not Found</h1>} />
+				</Routes>
 				</div>
 			</div>
-		</Router>
-    );
+	);
 };
 
 export default App;

--- a/src/api/GetAPI.ts
+++ b/src/api/GetAPI.ts
@@ -9,10 +9,14 @@ export const fetchAssignments = async (token: string | null): Promise<Assignment
         const headers = token ? { Authorization: `Bearer ${token}` } : {};
         const response = await axios.get(`${API_PREFIX}/assignments/`, { headers });
         return response.data;
-    } catch (error) {
-        throw new Error('課題データの取得に失敗しました');
+    } catch (error: any) { // error の型を any にすることで詳細情報を保持
+        const customError = new Error('課題データの取得に失敗しました');
+        customError.stack = error.stack; // 元のスタックトレースを保持
+        (customError as any).originalError = error; // 元のエラーをプロパティとして保持
+        throw customError;
     }
 };
+
 
 // APIから課題中の基本課題と発展課題を取得する関数
 export const fetchSubAssignments = async (id: string, token: string | null): Promise<SubAssignmentDropdown[]> => {
@@ -44,4 +48,19 @@ export const fetchUserList = async (token: string | null): Promise<User[]> => {
     } catch (error) {
         throw error;
     }
+};
+
+export const updateToken = async (token: string | null): Promise<string | null> => {
+    try {
+        const headers = token ? { Authorization: `Bearer ${token}` } : {};
+        const response = await axios.get(`${API_PREFIX}/authorize/token/update`, { headers,
+            withCredentials: true // クッキーを送信するために必要
+        });
+        if (response.data.is_valid && response.data.access_token) {
+            return response.data.access_token;
+        }
+    } catch (error) {
+        console.error('トークンの更新に失敗しました', error);
+    }
+    return null;
 };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,15 +4,17 @@ import styled from 'styled-components';
 import { Assignment } from '../types/Assignments';
 import { fetchAssignments } from '../api/GetAPI';
 import { useAuth } from '../context/AuthContext';
+import useApiClient from '../hooks/useApiClient';
 
 const Sidebar: React.FC = () => {
 	const { token, logout } = useAuth();
 	const [assignments, setAssignments] = useState<Assignment[]>([]);
+	const { apiClient } = useApiClient();
 	
 	useEffect(() => {
 		const getAssignments = async () => {
-		const assignmentsData = await fetchAssignments(token);
-		setAssignments(assignmentsData);
+			const assignmentsData = await apiClient(fetchAssignments);
+			setAssignments(assignmentsData);
 		};
 
 		getAssignments();

--- a/src/components/StudentListUploadBox.tsx
+++ b/src/components/StudentListUploadBox.tsx
@@ -1,0 +1,144 @@
+import React, { useState, useRef } from 'react';
+import { uploadStudentList } from '../api/PostAPI';
+import { ProgressMessage } from '../types/Assignments';
+import useApiClient from '../hooks/useApiClient';
+
+const StudentListUpload: React.FC = () => {
+    const [file, setFile] = useState<File | null>(null);
+    const [isNameCorrect, setIsNameCorrect] = useState<boolean | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [isUploading, setIsUploading] = useState<boolean>(false);
+    const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
+    const [downloadFileName, setDownloadFileName] = useState<string>(''); // ファイル名を動的に設定
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const { apiClient } = useApiClient();
+
+    const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setIsNameCorrect(null);
+        const files = event.target.files;
+        processFile(files);
+    };
+
+    const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+    };
+
+    const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        const files = event.dataTransfer.files;
+        processFile(files);
+        setError(null);
+    };
+
+    const processFile = (files: FileList | null) => {
+        if (files && files[0]) {
+            const selectedFile = files[0];
+            setFile(selectedFile);
+            if (selectedFile.name.endsWith('.csv') || selectedFile.name.endsWith('.xlsx')) {
+                setIsNameCorrect(true);
+            } else {
+                setIsNameCorrect(false);
+            }
+        }
+    };
+
+    const handleCancel = () => {
+        setFile(null);
+        setIsNameCorrect(null);
+        setError(null);
+        setDownloadUrl(null);
+        setDownloadFileName(''); // ダウンロードファイル名をリセット
+        if (fileInputRef.current) {
+            fileInputRef.current.value = '';
+        }
+    };
+
+    const handleSubmit = async (event: React.FormEvent) => {
+        event.preventDefault();
+        if (file && isNameCorrect) {
+            setIsUploading(true);
+            setError(null);
+            setDownloadUrl(null);
+
+            try {
+                const { data: blob, headers } = await apiClient(uploadStudentList, file);
+                
+                // Content-Dispositionヘッダーからファイル名を取得
+                const contentDisposition = headers['content-disposition'];
+                const fileName = contentDisposition
+                    ? contentDisposition.split('filename=')[1].replace(/['"]/g, '')
+                    : 'downloaded_file.xlsx'; // デフォルトのファイル名
+
+                setDownloadFileName(fileName); // 動的に取得したファイル名を設定
+                const url = window.URL.createObjectURL(blob);
+                setDownloadUrl(url);
+            } catch (error) {
+                console.error('Error uploading file', error);
+                setError('Failed to upload the file.');
+            } finally {
+                setIsUploading(false); // アップロード完了後、ボタンを再度有効化
+            }
+        }
+    };
+
+    return (
+        <>
+            <div
+                style={{
+                    backgroundColor: '#f0f0f0',
+                    padding: '20px',
+                    borderRadius: '5px',
+                    border: '1px solid #ddd',
+                    textAlign: 'center',
+                    minHeight: '150px',
+                }}
+                onDragOver={handleDragOver}
+                onDrop={handleDrop}
+            >
+                <p>{file ? file.name : 'ファイルを選択してください'}</p>
+                <p style={{ color: 'red', minHeight: '20px' }}>
+                    {isNameCorrect !== null && !isNameCorrect ? `ファイルはcsvかxlsxのものを選択してください．` : ''}
+                </p>
+                <input type="file" onChange={handleFileChange} ref={fileInputRef} style={{ display: 'none' }} />
+                <button
+                    disabled={isUploading}
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    style={{ width: 'auto', padding: '10px', margin: '10px 0' }}
+                >
+                    ファイルを選択
+                </button>
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'center', gap: '10px', marginTop: '20px' }}>
+                <button
+                    type="button"
+                    onClick={handleCancel}
+                    disabled={!file || isUploading}
+                    style={{ width: 'auto', padding: '10px' }}
+                >
+                    選択取り消し
+                </button>
+                <button
+                    type="button"
+                    onClick={handleSubmit}
+                    disabled={!file || !isNameCorrect || isUploading}
+                    style={{ width: 'auto', padding: '10px' }}
+                >
+                    アップロード
+                </button>
+            </div>
+            {/* アップロードが成功した場合のダウンロードリンク表示 */}
+            {downloadUrl && file && (
+                <div style={{ textAlign: 'center', marginTop: '20px' }}>
+                    <a href={downloadUrl} download={downloadFileName} style={{ padding: '10px', color: 'blue' }}>
+                        ここをクリックしてファイルをダウンロード
+                    </a>
+                </div>
+            )}
+            {/* エラーメッセージ表示 */}
+            {error && <p style={{ color: 'red', textAlign: 'center' }}>{error}</p>}
+        </>
+    );
+};
+
+export default StudentListUpload;

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -34,6 +34,7 @@ export const UserList: React.FC<UserListProps> = ({ user_id, users, selectedUser
             <tr style={{backgroundColor: '#f2f2f2', borderBottom: '3px solid black'}}>
             <th style={{padding: '10px', borderRight: '1px solid black'}}><input type="checkbox" onChange={handleSelectAll} checked={selectedUsers.length === users.length-1 && selectedUsers.length !== 0} /></th>
             <th style={{padding: '10px', borderRight: '1px solid black'}}>id</th>
+            <th style={{padding: '10px', borderRight: '1px solid black'}}>student_id</th>
             <th style={{padding: '10px', borderRight: '1px solid black'}}>username</th>
             <th style={{padding: '10px', borderRight: '1px solid black'}}>is_admin</th>
             <th style={{padding: '10px', borderRight: '1px solid black'}}>disabled</th>
@@ -48,6 +49,7 @@ export const UserList: React.FC<UserListProps> = ({ user_id, users, selectedUser
             <tr key={user.id} style={{backgroundColor: index % 2 === 0 ? '#ffffff' : '#f9f9f9', borderBottom: '1px solid black'}}>
                 <td style={{padding: '10px', borderRight: '1px solid black'}}><input type="checkbox" checked={selectedUsers.includes(user.id)} onChange={() => handleSelectUser(user.id)} disabled={user_id === user.id} /></td>
                 <td style={{padding: '10px', borderRight: '1px solid black'}}>{user.id}</td>
+                <td style={{padding: '10px', borderRight: '1px solid black'}}>{user.student_id}</td>
                 <td style={{padding: '10px', borderRight: '1px solid black'}}>{user.username}</td>
                 <td style={{padding: '10px', borderRight: '1px solid black'}}>{user.is_admin ? 'Yes' : 'No'}</td>
                 <td style={{padding: '10px', borderRight: '1px solid black'}}>{user.disabled ? 'Yes' : 'No'}</td>

--- a/src/hooks/useApiClient.ts
+++ b/src/hooks/useApiClient.ts
@@ -1,0 +1,57 @@
+import { useAuth } from '../context/AuthContext';
+import { updateToken } from '../api/GetAPI';
+
+const useApiClient = () => {
+    const { token, setToken, logout } = useAuth();
+
+    const refreshAccessToken = async (): Promise<string | null> => {
+        try {
+            const response = await updateToken(token);
+            if (response) {
+                const newToken = response;
+                setToken(newToken);
+                return newToken;
+            }
+        } catch (error) {
+            console.error('トークンのリフレッシュに失敗しました:', error);
+            return null;
+        }
+        return null;
+    };
+
+    const apiClient = async <T>(apiFunc: (...args: any[]) => Promise<T>, ...args: any[]): Promise<T> => {
+        // 引数がtokenを必要とする場合、tokenを自動的に追加
+        const needsToken = apiFunc.length > args.length; // 引数にtokenが必要かどうかを判定
+        const adjustedArgs = needsToken ? [...args, token] : args;
+        try {
+            // API関数を実行
+            console.log("First try")
+            return await apiFunc(...adjustedArgs);
+        } catch (error: any) {
+            console.log(`Error: ${error}, status: ${error.response?.status}`)
+            if (error.response?.status === 401) {
+                console.log("Token refreshed")
+                const refreshedToken = await refreshAccessToken();
+                if (refreshedToken) {
+                    const adjustedArgs = needsToken ? [...args, refreshedToken] : args;
+                    console.log("Second try")
+                    return await apiFunc(...adjustedArgs); // トークンをリフレッシュ後に再試行
+                } else {
+                    console.log("Logout")
+                    logout();
+                    throw new Error('セッションが切れました。再度ログインしてください。');
+                }
+            } else {
+                console.error('APIリクエストエラー:', error);
+                const errorMessage = '予期せぬエラーが発生しました。再度ログインしてください。';
+                alert(errorMessage);
+                logout();
+            }
+            throw error;
+        }
+    };
+
+    return { apiClient };
+};
+
+export default useApiClient;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,15 +4,18 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import {AuthProvider} from './context/AuthContext';
+import { BrowserRouter as Router } from 'react-router-dom';
 
 const root = ReactDOM.createRoot(
 	document.getElementById('root') as HTMLElement
 );
 root.render(
 	<React.StrictMode>
-		<AuthProvider>
-		<App />
-		</AuthProvider>
+		<Router>
+			<AuthProvider>
+				<App />
+			</AuthProvider>
+		</Router>
 	</React.StrictMode>
 );
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,12 +1,37 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import styled, { createGlobalStyle } from 'styled-components';
 import { login } from '../api/PostAPI';
 import { LoginCredentials } from '../types/user';
 import { useAuth } from '../context/AuthContext';
+import useApiClient from '../hooks/useApiClient';
+import { validateToken } from '../api/PostAPI';
+import { Navigate, useNavigate } from 'react-router-dom';
 
 const LoginPage: React.FC = () => {
-    const [credentials, setCredentials] = useState<LoginCredentials>({ username: '', password: '' });
+    const [credentials, setCredentials] = useState<LoginCredentials>({ student_id: '', password: '' });
     const [error, setError] = useState<string>('');
-    const { setToken, setUserId, setIsAdmin } = useAuth();
+    const { token, setToken, setUserId, setIsAdmin } = useAuth();
+    const { apiClient } = useApiClient();
+    const [isTokenValid, setIsTokenValid] = useState<boolean | null>(null); // トークンの有効性を保持
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        const validate = async () => {
+            if (token) {
+                try {
+                    const isValid = await apiClient(validateToken);
+                    setIsTokenValid(isValid);
+                } catch (error) {
+                    console.error('トークン検証エラー:', error);
+                    setIsTokenValid(false); // 検証に失敗した場合は無効とする
+                }
+            } else {
+                setIsTokenValid(false); // トークンがない場合は無効とする
+            }
+        };
+        validate();
+    }, [token]);
+
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setCredentials({ ...credentials, [e.target.name]: e.target.value });
@@ -20,42 +45,138 @@ const LoginPage: React.FC = () => {
             setToken(result.access_token); 
             setUserId(result.user_id);
             setIsAdmin(result.is_admin); 
-            window.location.href = '/';
+            const redirectUrl = sessionStorage.getItem("redirectUrl");
+
+            // リダイレクトURLがあればそのページへ、なければホームへ
+            if (redirectUrl) {
+                navigate(redirectUrl);
+                sessionStorage.removeItem("redirectUrl"); // 使用後は削除
+            } else {
+                navigate("/");
+            }
         } catch (error) {
             console.error('Login failed:', error);
             setError(`ログインに失敗しました。: ${(error as any).response.data.detail}`);
         }
     };
 
+    if (isTokenValid) {
+        return <Navigate to="/" replace />;
+    }
+
+    // トークンの検証中は何も表示しない
+    if (isTokenValid === null) {
+        return null; // ローディング中やスピナーを表示しても良い
+    }
     return (
-        <div className="login-page">
-            <h2>ログイン</h2>
-            {error && <p style={{ color: 'red' }}>{error}</p>}
-            <form onSubmit={handleSubmit}>
-                <div>
-                <label htmlFor="username">ユーザー名:</label>
-                <input
-                    type="text"
-                    id="username"
-                    name="username"
-                    value={credentials.username}
-                    onChange={handleChange}
-                />
-                </div>
-                <div>
-                <label htmlFor="password">パスワード:</label>
-                <input
-                    type="password"
-                    id="password"
-                    name="password"
-                    value={credentials.password}
-                    onChange={handleChange}
-                />
-                </div>
-                <button type="submit">ログイン</button>
-            </form>
-        </div>
+        <>
+            <GlobalStyle /> {/* ログイン画面用のグローバルスタイルを適用 */}
+            <PageContainer>
+                <FormContainer onSubmit={handleSubmit}>
+                    <h2>ログイン</h2>
+                    {error && <ErrorMessage>{error}</ErrorMessage>}
+                    <FormGroup>
+                        <Label htmlFor="student_id">学籍番号（例: 202312345）:</Label>
+                        <Input
+                            type="text"
+                            id="student_id"
+                            name="student_id"
+                            value={credentials.student_id}
+                            onChange={handleChange}
+                            autoComplete="username"
+                            required
+                        />
+                    </FormGroup>
+                    <FormGroup>
+                        <Label htmlFor="password">パスワード:</Label>
+                        <Input
+                            type="password"
+                            id="password"
+                            name="password"
+                            value={credentials.password}
+                            onChange={handleChange}
+                            autoComplete="current-password"
+                            required
+                        />
+                    </FormGroup>
+                    <Button type="submit">ログイン</Button>
+                </FormContainer>
+            </PageContainer>
+        </>
     );
 };
 
 export default LoginPage;
+
+const GlobalStyle = createGlobalStyle`
+  *, *::before, *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    }
+
+    .app {
+        display: block; /* ログイン画面ではフレックスを解除 */
+        height: auto;
+    .content {
+        margin: 0; /* ログイン画面ではmarginをリセット */
+        padding: 0;
+        width: 100%; /* ログイン画面で幅を100%にする */
+    }
+`;
+
+
+const PageContainer = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    background-color: #f5f5f5;
+    padding: 0 20px; /* 左右に均等な余白を持たせる */
+`;
+
+
+const FormContainer = styled.form`
+    background-color: white;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    width: 300px;
+`;
+
+const FormGroup = styled.div`
+    margin-bottom: 1rem;
+`;
+
+const Label = styled.label`
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: bold;
+`;
+
+const Input = styled.input`
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+`;
+
+const Button = styled.button`
+    width: 100%;
+    padding: 0.75rem;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 1rem;
+
+    &:hover {
+        background-color: #0056b3;
+    }
+`;
+
+const ErrorMessage = styled.p`
+    color: red;
+    margin-bottom: 1rem;
+`;

--- a/src/pages/SubmissionPage.tsx
+++ b/src/pages/SubmissionPage.tsx
@@ -6,20 +6,21 @@ import Dropdown from '../components/Dropdown';
 import CodeBlock from '../components/CodeBlock';
 import Accordion from '../components/Accordion';
 import FileUploadBox from '../components/FileUploadBox';
-import {useAuth} from '../context/AuthContext';
 import { ProgressMessage } from '../types/Assignments';
 import ProgressBar from '../components/ProgressBar';
+import useApiClient from '../hooks/useApiClient';
 const SubmissionPage: React.FC = () => {
 	const { problemNum } = useParams<{ problemNum: string }>();
 	const [subAssignmentsDropdown, setSubAssignmentsDropdown] = useState<SubAssignmentDropdown[]>([]);
 	const [subAssignmentDetail, setSubAssignmentDetail] = useState<SubAssignmentDetail | null>(null);
 	const [progressMessage, setProgressMessage] = useState<ProgressMessage | null>(null);
 	const [hasError, setHasError] = useState(false);
-	const { token } = useAuth();
+	const { apiClient } = useApiClient();
+
 	useEffect(() => {
 		const getSubAssignmentsDropdown = async () => {
 			try {
-				const data = await fetchSubAssignments(problemNum ?? '', token);
+				const data = await apiClient(fetchSubAssignments, problemNum ?? '');
 				setSubAssignmentsDropdown(data);
 				setHasError(false); // 成功した場合はエラー状態をリセット
 			} catch (error) {
@@ -38,7 +39,7 @@ const SubmissionPage: React.FC = () => {
 			return;
 		}
 		try {
-			const detail = await fetchSubAssignmentDetail(id.toString(), subId.toString(), token);
+			const detail = await apiClient(fetchSubAssignmentDetail, id.toString(), subId.toString());
 			setSubAssignmentDetail(detail);
 			setHasError(false); // 成功した場合はエラー状態をリセット
 		} catch (error) {

--- a/src/pages/UserDeletePage.tsx
+++ b/src/pages/UserDeletePage.tsx
@@ -5,8 +5,10 @@ import { useAuth } from '../context/AuthContext';
 import { deleteUsers } from '../api/DeleteAPI';
 import { UserList } from '../components/UserList';
 import { UserDelete } from '../types/user';
+import useApiClient from '../hooks/useApiClient';
 
 const UserDeletePage: React.FC = () => {
+    const { apiClient } = useApiClient();
     const [users, setUsers] = useState<User[]>([]);
     const [selectedUsers, setSelectedUsers] = useState<number[]>([]);
     const [error, setError] = useState('');
@@ -15,7 +17,7 @@ const UserDeletePage: React.FC = () => {
     useEffect(() => {
         const getUsers = async () => {
             try {
-                const userList = await fetchUserList(token);
+                const userList = await apiClient(fetchUserList);
                 setUsers(userList);
             } catch (error) {
                 console.error('ユーザーの取得に失敗しました。', error);
@@ -33,9 +35,9 @@ const UserDeletePage: React.FC = () => {
         }
         
         try {
-            await deleteUsers({user_ids: selectedUsers}, token);
+            await apiClient(deleteUsers, {user_ids: selectedUsers});
             alert('選択されたユーザーが正常に削除されました。');
-            const updatedUserList = await fetchUserList(token);
+            const updatedUserList = await apiClient(fetchUserList);
             setUsers(updatedUserList);
             setSelectedUsers([]);
         } catch (error) {

--- a/src/pages/UserRegisterationPage.tsx
+++ b/src/pages/UserRegisterationPage.tsx
@@ -2,21 +2,35 @@ import React, { useState } from 'react';
 import { createUser } from '../api/PostAPI';
 import { CreateUser } from '../types/user';
 import {useAuth} from '../context/AuthContext';
+import StudentListUploadBox from '../components/StudentListUploadBox';
 
 const RegisterPage: React.FC = () => {
+    const [student_id, setStudentId] = useState('');
     const [username, setUsername] = useState('');
+    const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [confirmPassword, setConfirmPassword] = useState('');
     const [is_admin, setIsAdmin] = useState(false);
     const [disabled, setDisabled] = useState(false);
     const [activeStartDate, setActiveStartDate] = useState('');
     const [activeEndDate, setActiveEndDate] = useState('');
-    const { token } = useAuth();
+    const { token, user_id, is_admin: is_admin_user } = useAuth(); // useAuthから現在のユーザー情報も取得する
     // const [authCode, setAuthCode] = useState('');
     const [error, setError] = useState('');
 
     const handleRegister = async (e: React.FormEvent) => {
         e.preventDefault();
+
+        if (!email.includes('@')) {
+            setError('メールアドレスの形式が正しくありません。');
+            return;
+        }
+
+        if (!email.endsWith('tsukuba.ac.jp')) {
+            setError('tsukuba.ac.jpで終わるメールアドレスを入力してください。');
+            return;
+        }
+
         if (password !== confirmPassword) {
             setError('パスワードが一致しません。');
             return;
@@ -28,7 +42,9 @@ const RegisterPage: React.FC = () => {
         }
 
         const newUser: CreateUser = {
+            student_id,
             username,
+            email,
             password,
             is_admin,
             disabled,
@@ -41,6 +57,7 @@ const RegisterPage: React.FC = () => {
             await createUser(newUser, token);
             alert('アカウントが正常に作成されました。');
             setUsername('');
+            setEmail('');
             setPassword('');
             setConfirmPassword('');
             setIsAdmin(false);
@@ -55,14 +72,29 @@ const RegisterPage: React.FC = () => {
         }
     };
 
+    if (user_id === null) {
+        return <p>ログインしていません。</p>;
+    }
+    if (!is_admin_user) {
+        return <p>管理者権限がありません。</p>;
+    }
+
     return (
         <div>
             <h2>アカウント登録</h2>
             {error && <p style={{ color: 'red' }}>{error}</p>}
             <form onSubmit={handleRegister}>
                 <div>
+                    <label>学籍番号:</label>
+                    <input type="text" value={student_id} onChange={(e) => setStudentId(e.target.value)} required />
+                </div>
+                <div>
                     <label>ユーザー名:</label>
                     <input type="text" value={username} onChange={(e) => setUsername(e.target.value)} required />
+                </div>
+                <div>
+                    <label>メールアドレス:</label>
+                    <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
                 </div>
                 <div>
                     <label>パスワード:</label>
@@ -94,6 +126,7 @@ const RegisterPage: React.FC = () => {
                 </div>
                 <button type="submit">登録</button>
             </form>
+            <StudentListUploadBox />
         </div>
     );
 };

--- a/src/pages/UserRegisterationPage.tsx
+++ b/src/pages/UserRegisterationPage.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import { createUser } from '../api/PostAPI';
 import { CreateUser } from '../types/user';
-import {useAuth} from '../context/AuthContext';
+import { useAuth } from '../context/AuthContext';
 import StudentListUploadBox from '../components/StudentListUploadBox';
+import useApiClient from '../hooks/useApiClient';
 
 const RegisterPage: React.FC = () => {
     const [student_id, setStudentId] = useState('');
@@ -14,8 +15,8 @@ const RegisterPage: React.FC = () => {
     const [disabled, setDisabled] = useState(false);
     const [activeStartDate, setActiveStartDate] = useState('');
     const [activeEndDate, setActiveEndDate] = useState('');
-    const { token, user_id, is_admin: is_admin_user } = useAuth(); // useAuthから現在のユーザー情報も取得する
-    // const [authCode, setAuthCode] = useState('');
+    const { apiClient } = useApiClient();
+    const { user_id, is_admin: is_admin_user, logout } = useAuth(); // useAuthから現在のユーザー情報も取得する
     const [error, setError] = useState('');
 
     const handleRegister = async (e: React.FormEvent) => {
@@ -48,13 +49,12 @@ const RegisterPage: React.FC = () => {
             password,
             is_admin,
             disabled,
-            active_start_date: activeStartDate || null, // 空文字列の場合はnullを設定
-            active_end_date: activeEndDate || null, // 空文字列の場合はnullを設定
-            // auth_code: '', // auth_codeは空文字列で設定
+            active_start_date: activeStartDate || null,
+            active_end_date: activeEndDate || null,
         };
 
         try {
-            await createUser(newUser, token);
+            await apiClient(createUser, newUser);
             alert('アカウントが正常に作成されました。');
             setUsername('');
             setEmail('');
@@ -73,7 +73,7 @@ const RegisterPage: React.FC = () => {
     };
 
     if (user_id === null) {
-        return <p>ログインしていません。</p>;
+        logout();
     }
     if (!is_admin_user) {
         return <p>管理者権限がありません。</p>;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -29,7 +29,6 @@ export type CreateUser = {
     updated_at?: string | null;
     active_start_date?: string | null;
     active_end_date?: string | null;
-    // auth_code: string;
 }
 
 export type UserDelete = {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,4 +1,5 @@
 export type UserBase = {
+    student_id: string;
     username: string;
     is_admin: boolean;
     disabled: boolean;
@@ -13,12 +14,14 @@ export type User = UserBase & {
 }
 
 export type LoginCredentials = {
-    username: string;
+    student_id: string;
     password: string;
 }
 
 export type CreateUser = {
+    student_id: string;
     username: string;
+    email: string;
     password: string;
     is_admin: boolean;
     disabled: boolean;


### PR DESCRIPTION
元々はログインしなくても公開中の課題画面にはアクセス可能だったが，ログインしないとアクセスできないようにした．
各学生にアカウントを用意することになるため，xlsxかcsvで学生情報をまとめたものをアップロードすることで一括でランダムなパスワードが生成されアカウント登録ができるようになっている．

細かいことは
https://github.com/zakkii-k/dsa_back/pull/10
を参照．


アクセストークンとリフレッシュトークンを導入したため，APIを叩くたびにトークンのチェックが走る．もしアクセストークンが失効している場合は一旦中断し，リフレッシュトークンを用いてアクセストークンの更新を行うためのAPIを叩く．新しいアクセストークンを取得できたらそれをストレージに記録し，再度最初に叩いていたAPIを叩き直す．
ほぼ全てのAPI関数でこの処理を行うため，useApiClientとhookを導入した．APIを叩く時は，
```
import useApiClient from <path>
```

でimportした後，

```
const { apiClient } = useApiClient()
const result = await apiClient(func, arg1, arg2);
```
のように使用できる．なお，apiClientの中でtokenを取得する実装を含めているので，外からtokenを取得するためだけにuseAuthを使用する必要もない．

