### PR TITLE
[improvement]バッチ採点リクエストの提出ページで、ローディング中はアップロードボタンを無効にするように修正

### DIFF
--- a/src/components/FileUploadBox.tsx
+++ b/src/components/FileUploadBox.tsx
@@ -16,9 +16,10 @@ import { CloudUpload, InsertDriveFile, Delete } from '@mui/icons-material';
 interface FileUploadFormProps {
     onSubmit: (files: File[]) => void;
     descriptionOnBox: string;
+    isSubmitting?: boolean;
 }
 
-const FileUploadBox: React.FC<FileUploadFormProps> = ({ onSubmit, descriptionOnBox }) => {
+const FileUploadBox: React.FC<FileUploadFormProps> = ({ onSubmit, descriptionOnBox, isSubmitting }) => {
     const [files, setFiles] = useState<File[]>([]);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const [inputKey, setInputKey] = useState(Date.now());
@@ -109,9 +110,9 @@ const FileUploadBox: React.FC<FileUploadFormProps> = ({ onSubmit, descriptionOnB
                 <Button
                     variant="contained"
                     onClick={handleSubmit}
-                    disabled={files.length === 0}
+                    disabled={files.length === 0 || isSubmitting}
                 >
-                    提出
+                    {isSubmitting ? '提出中...' : '提出'}
                 </Button>
             </Box>
         </Box>

--- a/src/components/StudentListUploadBox.tsx
+++ b/src/components/StudentListUploadBox.tsx
@@ -111,6 +111,30 @@ const StudentListUpload: React.FC = () => {
                 <p style={{ color: 'red', minHeight: '20px' }}>
                     {isNameCorrect !== null && !isNameCorrect ? `ファイルはcsvかxlsxのものを選択してください．` : ''}
                 </p>
+
+                {error && <p style={{ color: 'red', margin: '5px 0', padding: '8px', backgroundColor: '#ffebee', borderRadius: '4px' }}>{error}</p>}
+
+                {downloadUrl && file && (
+                    <div style={{
+                        margin: '10px 0',
+                        padding: '10px',
+                        backgroundColor: '#e3f2fd',
+                        borderRadius: '4px'
+                    }}>
+                        <p style={{ marginBottom: '5px' }}>ユーザー登録が完了しました</p>
+                        <a
+                            href={downloadUrl}
+                            download={downloadFileName}
+                            style={{
+                                color: '#1976d2',
+                                textDecoration: 'underline',
+                                fontWeight: 'bold'
+                            }}
+                        >
+                            パスワードリストをダウンロード
+                        </a>
+                    </div>
+                )}
                 <input type="file" onChange={handleFileChange} ref={fileInputRef} style={{ display: 'none' }} />
                 <button
                     disabled={isUploading}
@@ -136,19 +160,9 @@ const StudentListUpload: React.FC = () => {
                     disabled={!file || !isNameCorrect || isUploading}
                     style={{ width: 'auto', padding: '10px' }}
                 >
-                    アップロード
+                    {isUploading ? 'アップロード中...' : 'アップロード'}
                 </button>
             </div>
-            {/* アップロードが成功した場合のダウンロードリンク表示 */}
-            {downloadUrl && file && (
-                <div style={{ textAlign: 'center', marginTop: '20px' }}>
-                    <a href={downloadUrl} download={downloadFileName} style={{ padding: '10px', color: 'blue' }}>
-                        ここをクリックしてファイルをダウンロード
-                    </a>
-                </div>
-            )}
-            {/* エラーメッセージ表示 */}
-            {error && <p style={{ color: 'red', textAlign: 'center' }}>{error}</p>}
         </>
     );
 };

--- a/src/pages/BatchSubmission.tsx
+++ b/src/pages/BatchSubmission.tsx
@@ -11,6 +11,7 @@ const BatchSubmission: React.FC = () => {
   const [lectures, setLectures] = useState<Lecture[]>([]);
   const [selectedLecture, setSelectedLecture] = useState<number | ''>('');
   const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const { token } = useAuth();
   const { apiClient } = useApiClient();
   const navigate = useNavigate();
@@ -30,6 +31,10 @@ const BatchSubmission: React.FC = () => {
   }, [token]);
 
   const handleSubmit = async (files: File[]) => {
+    if (isSubmitting) {
+      return;
+    }
+
     if (files.length !== 1) {
       setError('ファイルは一つだけアップロードしてください');
       return;
@@ -47,6 +52,7 @@ const BatchSubmission: React.FC = () => {
     }
 
     try {
+      setIsSubmitting(true);
       await apiClient({ apiFunc: submitBatchEvaluation, args: [Number(selectedLecture), true, uploadedFile]});
       alert('バッチ採点が正常に提出されました');
       setSelectedLecture('');
@@ -54,6 +60,8 @@ const BatchSubmission: React.FC = () => {
     } catch (error) {
       console.error('Error submitting batch evaluation:', error);
       setError('バッチ採点の提出に失敗しました');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -80,6 +88,7 @@ const BatchSubmission: React.FC = () => {
       <FileUploadBox
         onSubmit={handleSubmit}
         descriptionOnBox='zipファイル一つをアップロードしてください'
+        isSubmitting={isSubmitting}
       />
       {error && <p className='error'>{error}</p>}
     </div>

--- a/src/pages/ProblemPage.tsx
+++ b/src/pages/ProblemPage.tsx
@@ -16,6 +16,7 @@ const SubmissionPage: React.FC = () => {
 	const { apiClient } = useApiClient();
 	const [hasError, setHasError] = useState<boolean>(false);
 	const navigate = useNavigate();
+	const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
 	const isAdminOrManager = role === UserRole.admin || role === UserRole.manager;
 
@@ -43,6 +44,10 @@ const SubmissionPage: React.FC = () => {
 	}, [lectureId, assignmentId, token]);
 
 	const handleSubmit = async (files: File[]) => {
+		if (isSubmitting) {
+			return;
+		}
+
 		if (lectureId && assignmentId) {
 			// 必要なファイルが全てアップロードされているか確認
 			const uploadedFileNames = files.map(file => file.name);
@@ -85,7 +90,7 @@ const SubmissionPage: React.FC = () => {
 			</div>
 			<div>
 				<h1>提出フォーム</h1>
-				<FileUploadBox onSubmit={handleSubmit} descriptionOnBox={'zipではなく各ファイルを提出してください．'} />
+				<FileUploadBox onSubmit={handleSubmit} descriptionOnBox={'zipではなく各ファイルを提出してください．'} isSubmitting={isSubmitting} />
 			</div>
 		</div>
 	);


### PR DESCRIPTION
* バッチ採点リクエストの提出ページで、ローディング中はアップロードボタンを無効にするように修正
* ユーザ登録ページにて、パスワードリストのアップロードボタンが見づらい問題を修正
